### PR TITLE
Include Lagrange multipliers in results from OPF

### DIFF
--- a/pandapower/results.py
+++ b/pandapower/results.py
@@ -89,8 +89,17 @@ def _copy_results_ppci_to_ppc(result, ppc, mode):
 
     # copy the results for bus, gen and branch
     # busses are sorted (REF, PV, PQ, NONE) -> results are the first 3 types
-    n_cols = np.shape(ppc['bus'])[1]
-    ppc['bus'][:len(result['bus']), :n_cols] = result['bus'][:len(result['bus']), :n_cols]
+    n_busses, n_cols = np.shape(ppc['bus'])
+    n_rows_result, n_cols_result = np.shape(result['bus'])
+    # create matrix of proper size
+    updated_bus = np.empty((n_busses, n_cols_result))
+    # fill in results (first 3 types) 
+    updated_bus[:n_rows_result, :] = result['bus']
+    if n_busses > n_rows_result:
+        # keep rows for busses of type NONE
+        updated_bus[n_rows_result:,:n_cols] = ppc['bus'][n_rows_result:,:]
+    ppc['bus']= updated_bus
+    
     if mode == "sc":
         ppc['bus_sc'][:len(result['bus']), :n_cols] = result['bus_sc'][:len(result['bus']), :n_cols]
     # in service branches and gens are taken from 'internal'

--- a/pandapower/results_bus.py
+++ b/pandapower/results_bus.py
@@ -6,7 +6,7 @@
 
 import numpy as np
 from numpy import zeros, array, float, hstack, invert
-from pypower.idx_bus import VM, VA, PD, QD
+from pypower.idx_bus import VM, VA, PD, QD, LAM_P, LAM_Q
 from pypower.idx_gen import PG, QG
 
 from pandapower.auxiliary import _sum_by_group
@@ -75,7 +75,7 @@ def _set_buses_out_of_service(ppc):
 
 def _get_bus_results(net, ppc, bus_pq):
     ac = net["_options"]["ac"]
-
+    mode = net["_options"]["mode"]
     net["res_bus"]["p_kw"] = bus_pq[:, 0]
     if ac:
         net["res_bus"]["q_kvar"] = bus_pq[:, 1]
@@ -88,6 +88,11 @@ def _get_bus_results(net, ppc, bus_pq):
     net["res_bus"].index = net["bus"].index
     # voltage angles
     net["res_bus"]["va_degree"] = ppc["bus"][bus_idx][:, VA]
+
+    if mode == "opf":
+        # marginal prices
+        net["res_bus"]["lam_p"] = ppc["bus"][bus_idx][:, LAM_P]
+        net["res_bus"]["lam_q"] = ppc["bus"][bus_idx][:, LAM_Q]
 
 
 def _get_p_q_results(net, bus_lookup_aranged):


### PR DESCRIPTION
Comments welcome.

For me the test `test_IEEE_case_9_with_bad_data` is failing, but it also fails on `develop`.