### PR TITLE
Fix pandas requirement specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url='http://www.uni-kassel.de/go/pandapower',
     license='BSD',
     install_requires=["pypower>=5.0.1",
-                      "pandas>=0.17.0<0.20",
+                      "pandas>=0.17.0,<0.20",
                       "networkx",
                       "numpy",
                       "scipy"],


### PR DESCRIPTION
Corrects the following errors:
```
error in pandapower setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers
```

```
Expected ',' or end-of-list in pandas>=0.17.0<0.20 at <0.20
```

