### PR TITLE
Added keys to trafo3w results function

### DIFF
--- a/pandapower/shortcircuit/results.py
+++ b/pandapower/shortcircuit/results.py
@@ -60,5 +60,5 @@ def _get_trafo3w_results(net, ppc):
         mv = int(f + 2 * (t - f) / 3)
         lv = t
         net.res_trafo3w_sc["ikss_hv_ka"] = ppc["branch"][f:hv, IKSS_F].real * 1e3
-        net.res_trafo3w_sc = ppc["branch"][hv:mv, IKSS_T].real * 1e3
-        net.res_trafo3w_sc = ppc["branch"][mv:lv, IKSS_T].real * 1e3
+        net.res_trafo3w_sc["ikss_mv_ka"] = ppc["branch"][hv:mv, IKSS_T].real * 1e3
+        net.res_trafo3w_sc["ikss_lv_ka"] = ppc["branch"][mv:lv, IKSS_T].real * 1e3


### PR DESCRIPTION
There seem to be a couple of keys missing from `_get_trafo3w_results`.