### PR TITLE
Speed improvements

### DIFF
--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -420,7 +420,7 @@ def _trafo_df_from_trafo3w(net):
     nr_trafos = len(net["trafo3w"])
     tap_variables = ("tp_pos", "tp_mid", "tp_max", "tp_min", "tp_st_percent", "tp_st_degree")
     i = 0
-    for _, ttab in net["trafo3w"].iterrows():
+    for ttab in net["trafo3w"].itertuples():
         vsc = np.array([ttab.vsc_hv_percent, ttab.vsc_mv_percent, ttab.vsc_lv_percent], dtype=float)
         vscr = np.array([ttab.vscr_hv_percent, ttab.vscr_mv_percent, ttab.vscr_lv_percent], dtype=float)
         sn = np.array([ttab.sn_hv_kva, ttab.sn_mv_kva, ttab.sn_lv_kva])
@@ -448,7 +448,7 @@ def _trafo_df_from_trafo3w(net):
             elif ttab.tp_side == "lv":
                 tp_trafo = 2
             for tv in tap_variables:
-                taps[tp_trafo][tv] = ttab[tv]
+                taps[tp_trafo][tv] = getattr(ttab,tv)
             # consider where the tap is located - at the bus or at star point of the 3W-transformer
             if not trafo3w_tap_at_star_point:
                 taps[tp_trafo]["tp_side"] = "hv" if tp_trafo == 0 else "lv"

--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -456,7 +456,7 @@ def _trafo_df_from_trafo3w(net):
                 taps[tp_trafo]["tp_side"] = "lv" if tp_trafo == 0 else "hv"
                 taps[tp_trafo]["tp_st_degree"] += 180
 
-        max_load = ttab.max_loading_percent if "max_loading_percent" in ttab else 0
+        max_load = ttab.max_loading_percent if "max_loading_percent" in ttab._fields else 0
 
         trafos2w[i] = {"hv_bus": ttab.hv_bus, "lv_bus": ttab.ad_bus, "sn_kva": ttab.sn_hv_kva,
                        "vn_hv_kv": ttab.vn_hv_kv, "vn_lv_kv": ttab.vn_hv_kv,

--- a/pandapower/powerflow.py
+++ b/pandapower/powerflow.py
@@ -12,6 +12,7 @@ from pandapower.pf.run_dc_pf import _run_dc_pf
 from pandapower.pf.run_newton_raphson_pf import _run_newton_raphson_pf
 from pandapower.pf.runpf_pypower import _runpf_pypower
 from pandapower.results import _extract_results, _copy_results_ppci_to_ppc, reset_results, verify_results
+import pandas as pd
 
 
 class AlgorithmUnknown(ppException):
@@ -129,8 +130,7 @@ def _create_xward_buses(net):
     if init_results:
         # TODO: this is probably slow, but the whole auxiliary bus creation should be included in
         #      pd2ppc anyways. LT
-        for hv_bus, aux_bus in zip(main_buses.index, bid):
-            net.res_bus.loc[aux_bus] = net.res_bus.loc[hv_bus].values
+        net.res_bus=net.res_bus.append(pd.DataFrame(index=bid,data=net.res_bus.loc[main_buses.index].values,columns=net.res_bus.columns))
 
 
 def _create_trafo3w_buses(net):
@@ -146,8 +146,7 @@ def _create_trafo3w_buses(net):
     if init_results:
         # TODO: this is probably slow, but the whole auxiliary bus creation should be included in
         #      pd2ppc anyways. LT
-        for hv_bus, aux_bus in zip(hv_buses.index, bid):
-            net.res_bus.loc[aux_bus] = net.res_bus.loc[hv_bus].values
+        net.res_bus=net.res_bus.append(pd.DataFrame(index=bid,data=net.res_bus.loc[hv_buses.index].values,columns=net.res_bus.columns))
 
 
 def _add_dcline_gens(net):


### PR DESCRIPTION
I changed iterrows to itertuples for creating three-winding transformers, because it is significantly faster. This speeds up the function from about 0.8 seconds to 0.2 seconds for 1000 three winding transformers. 
The best way would still be no iteration at all, but that would be more complex. 

I got rid of the iteration in the bus creation for extended wards and three-winding transformers, this has an even greater impact on speed with init='results', something like from 8 seconds down to less than 1 second.