### PR TITLE
Check if all trafo buses are in_service and set ad_bus accordingly

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -33,7 +33,7 @@ import pandas as pd
 import scipy as sp
 import six
 
-from pandapower.idx_brch import F_BUS, T_BUS
+from pandapower.idx_brch import F_BUS, T_BUS, BR_STATUS
 from pandapower.idx_bus import BUS_I, BUS_TYPE, NONE, PD, QD
 
 try:
@@ -281,10 +281,11 @@ def _check_connectivity(ppc):
     :param ppc: pypower case file
     :return:
     """
-    nobranch = ppc['branch'].shape[0]
+    br_status=ppc['branch'][:, BR_STATUS]==True
+    nobranch = ppc['branch'][br_status, :].shape[0]
     nobus = ppc['bus'].shape[0]
-    bus_from = ppc['branch'][:, F_BUS].real.astype(int)
-    bus_to = ppc['branch'][:, T_BUS].real.astype(int)
+    bus_from = ppc['branch'][br_status, F_BUS].real.astype(int)
+    bus_to = ppc['branch'][br_status, T_BUS].real.astype(int)
 
     slacks = ppc['bus'][ppc['bus'][:, BUS_TYPE] == 3, BUS_I]
 

--- a/pandapower/powerflow.py
+++ b/pandapower/powerflow.py
@@ -139,9 +139,12 @@ def _create_trafo3w_buses(net):
 
     init_results = init == "results"
     hv_buses = net.bus.loc[net.trafo3w.hv_bus.values]
+    mv_buses = net.bus.loc[net.trafo3w.mv_bus.values]
+    lv_buses = net.bus.loc[net.trafo3w.lv_bus.values]
     bid = create_buses(net, nr_buses=len(net["trafo3w"]),
                        vn_kv=hv_buses.vn_kv.values,
-                       in_service=net.trafo3w.in_service.values)
+                       in_service=net.trafo3w.in_service.values &
+                       (hv_buses.in_service.values | mv_buses.in_service.values | lv_buses.in_service.values))
     net.trafo3w["ad_bus"] = bid
     if init_results:
         # TODO: this is probably slow, but the whole auxiliary bus creation should be included in

--- a/pandapower/powerflow.py
+++ b/pandapower/powerflow.py
@@ -139,12 +139,9 @@ def _create_trafo3w_buses(net):
 
     init_results = init == "results"
     hv_buses = net.bus.loc[net.trafo3w.hv_bus.values]
-    mv_buses = net.bus.loc[net.trafo3w.mv_bus.values]
-    lv_buses = net.bus.loc[net.trafo3w.lv_bus.values]
     bid = create_buses(net, nr_buses=len(net["trafo3w"]),
                        vn_kv=hv_buses.vn_kv.values,
-                       in_service=net.trafo3w.in_service.values &
-                       (hv_buses.in_service.values | mv_buses.in_service.values | lv_buses.in_service.values))
+                       in_service=net.trafo3w.in_service.values)
     net.trafo3w["ad_bus"] = bid
     if init_results:
         # TODO: this is probably slow, but the whole auxiliary bus creation should be included in

--- a/pandapower/test/loadflow/test_scenarios.py
+++ b/pandapower/test/loadflow/test_scenarios.py
@@ -308,6 +308,27 @@ def test_two_oos_buses():
     pp.runpp(net)
     assert net.res_line.loading_percent.at[l1] > 0
     assert np.isnan(net.res_line.loading_percent.at[l3])
+
+def test_oos_buses_at_trafo3w():
+    net = pp.create_empty_network()
+
+    b1 = pp.create_bus(net, vn_kv=110.)
+    b2 = pp.create_bus(net, vn_kv=110.)
+    b3 = pp.create_bus(net, vn_kv=110., in_service=False)
+    b4 = pp.create_bus(net, vn_kv=20., in_service=False)
+    b5 = pp.create_bus(net, vn_kv=10., in_service=False)
+
+    pp.create_ext_grid(net, b1)
+    l1 = pp.create_line(net, b1, b2, 0.5, std_type="NAYY 4x50 SE", in_service=True)
+    l2 = pp.create_line(net, b2, b3, 0.5, std_type="NAYY 4x50 SE", in_service=False)
+
+    tidx = pp.create_transformer3w(net, b3, b4, b5, std_type='63/25/38 MVA 110/20/10 kV', in_service=True)
+
+    pp.runpp(net, trafo3w_losses = 'star', trafo_model= 'pi', init='flat')
+
+    assert net.res_line.loading_percent.at[l1] > 0
+    assert np.isnan(net.res_trafo3w.i_hv_ka.at[tidx])
+
     
 if __name__ == "__main__":
 #    test_volt_dep_load_at_inactive_bus()


### PR DESCRIPTION
This prevents an unsupplied ad_bus which is set in_service. Otherwise the powerflow cannot converge. I think with this #118 can be closed.